### PR TITLE
allow optional lpConduit param passthrough on liquidity actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crocswap-libs/sdk",
-  "version": "0.2.75",
+  "version": "0.2.76",
   "description": "🛠🐊🛠 An SDK for building applications on top of CrocSwap",
   "author": "Ben Wolski <ben@crocodilelabs.io>",
   "repository": "https://github.com/CrocSwap/sdk.git",

--- a/src/encoding/liquidity.ts
+++ b/src/encoding/liquidity.ts
@@ -1,7 +1,6 @@
 import { BigNumber, ethers } from "ethers";
 import { MAX_LIQ } from "../constants";
 import { encodeCrocPrice } from "../utils/price";
-import { AddressZero } from "@ethersproject/constants";
 
 type Address = string;
 type PoolType = number;
@@ -26,7 +25,8 @@ export class WarmPathEncoder {
     qtyIsBase: boolean,
     limitLow: number,
     limitHigh: number,
-    useSurplus: number
+    useSurplus: number,
+    lpConduit: Address
   ) {
     return this.encodeWarmPath(
       qtyIsBase ? MINT_CONC_BASE : MINT_CONC_QUOTE,
@@ -35,7 +35,8 @@ export class WarmPathEncoder {
       qty,
       limitLow,
       limitHigh,
-      useSurplus
+      useSurplus,
+      lpConduit
     );
   }
 
@@ -45,7 +46,8 @@ export class WarmPathEncoder {
     liq: BigNumber,
     limitLow: number,
     limitHigh: number,
-    useSurplus: number
+    useSurplus: number,
+    lpConduit: Address
   ) {
     return this.encodeWarmPath(
       BURN_CONCENTRATED,
@@ -54,7 +56,8 @@ export class WarmPathEncoder {
       liq,
       limitLow,
       limitHigh,
-      useSurplus
+      useSurplus,
+      lpConduit
     );
   }
 
@@ -63,7 +66,8 @@ export class WarmPathEncoder {
     upperTick: number,
     limitLow: number,
     limitHigh: number,
-    useSurplus: number
+    useSurplus: number,
+    lpConduit: Address
   ) {
     return this.encodeWarmPath(
       HARVEST_CONCENTRATED,
@@ -72,7 +76,8 @@ export class WarmPathEncoder {
       BigNumber.from(0),
       limitLow,
       limitHigh,
-      useSurplus
+      useSurplus,
+      lpConduit
     );
   }
 
@@ -81,7 +86,8 @@ export class WarmPathEncoder {
     qtyIsBase: boolean,
     limitLow: number,
     limitHigh: number,
-    useSurplus: number
+    useSurplus: number,
+    lpConduit: Address
   ) {
     return this.encodeWarmPath(
       qtyIsBase ? MINT_AMBIENT_BASE : MINT_AMBIENT_QUOTE,
@@ -90,7 +96,8 @@ export class WarmPathEncoder {
       qty,
       limitLow,
       limitHigh,
-      useSurplus
+      useSurplus,
+      lpConduit
     );
   }
 
@@ -98,7 +105,8 @@ export class WarmPathEncoder {
     liq: BigNumber,
     limitLow: number,
     limitHigh: number,
-    useSurplus: number
+    useSurplus: number,
+    lpConduit: Address
   ) {
     return this.encodeWarmPath(
       BURN_AMBIENT,
@@ -107,14 +115,16 @@ export class WarmPathEncoder {
       liq,
       limitLow,
       limitHigh,
-      useSurplus
+      useSurplus,
+      lpConduit
     );
   }
 
   encodeBurnAmbientAll(
     limitLow: number,
     limitHigh: number,
-    useSurplus: number
+    useSurplus: number,
+    lpConduit: Address
   ) {
     return this.encodeWarmPath(
       BURN_AMBIENT,
@@ -123,7 +133,8 @@ export class WarmPathEncoder {
       MAX_LIQ,
       limitLow,
       limitHigh,
-      useSurplus
+      useSurplus,
+      lpConduit
     );
   }
 
@@ -134,7 +145,8 @@ export class WarmPathEncoder {
     qty: BigNumber,
     limitLow: number,
     limitHigh: number,
-    useSurplus: number
+    useSurplus: number,
+    lpConduit: Address
   ): string {
     return this.abiCoder.encode(WARM_ARG_TYPES, [
       callCode,
@@ -147,7 +159,7 @@ export class WarmPathEncoder {
       encodeCrocPrice(limitLow),
       encodeCrocPrice(limitHigh),
       useSurplus,
-      AddressZero,
+      lpConduit,
     ]);
   }
 }

--- a/src/examples/demo.ts
+++ b/src/examples/demo.ts
@@ -1,4 +1,6 @@
 import { CrocEnv } from '../croc';
+import { CrocPositionView } from '../position';
+import { ERC20_READ_ABI } from '../abis/erc20.read';
 import { ethers } from 'ethers';
 
 //const ETH = ethers.constants.AddressZero
@@ -7,6 +9,9 @@ const USDC = "0xD87Ba7A50B2E7E660f678A895E4B72E7CB4CCd9C"
 
 // deepcode ignore HardcodedSecret: testnet dummy key
 const KEY = "0x7c5e2cfbba7b00ba95e5ed7cd80566021da709442e147ad3e08f23f5044a3d5a"
+
+// USDC/ETH lpConduit
+const USDC_ETH_LP_CONDUIT = "0x8c1A6FfA18183ef223d5Eb3b0A0208515E64bB88";
 
 async function demo() {
     const wallet = new ethers.Wallet(KEY)
@@ -190,6 +195,20 @@ async function demo() {
 
     /*console.log((await croc.tokenEth().balance("benwolski.eth")).toString())
     console.log(await croc.tokenEth().balanceDisplay("benwolski.eth"))*/
+
+    // await croc.poolEth(USDC).mintAmbientQuote(50, [0.0001, 0.001]);
+
+    // mint USDC/ETH lp tokens
+    // await croc.poolEth(USDC).mintAmbientQuote(50, [0.0001, 0.001], { lpConduit: USDC_ETH_LP_CONDUIT });
+    const lpConduitContract = new ethers.Contract(USDC_ETH_LP_CONDUIT, ERC20_READ_ABI, (await croc.context).provider);
+    const lpTokenBalance = await lpConduitContract.balanceOf(wallet.address);
+    console.log(ethers.utils.formatUnits(lpTokenBalance, 18));
+
+    // burn USDC/ETH lp tokens
+    const lpConduitPositionView = new CrocPositionView(pool, USDC_ETH_LP_CONDUIT);
+    const lpConduitPosition = await lpConduitPositionView.queryAmbient()
+    console.log(lpConduitPosition);
+    // await croc.poolEth(USDC).burnAmbientLiq(lpConduitPosition.seeds, [0.0001, 0.001], { lpConduit: USDC_ETH_LP_CONDUIT });
 }
 
 demo()

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -146,14 +146,14 @@ export class CrocPoolView {
         Promise<TransactionResponse> {
         let [lowerBound, upperBound] = await this.transformLimits(limits)
         const calldata = (await this.makeEncoder()).encodeBurnAmbient
-            (liq, lowerBound, upperBound, this.maskSurplusFlag(opts))
+            (liq, lowerBound, upperBound, this.maskSurplusFlag(opts), this.applyLpConduit(opts))
         return this.sendCmd(calldata)
     }
 
     async burnAmbientAll (limits: PriceRange, opts?: CrocLpOpts): Promise<TransactionResponse> {
         let [lowerBound, upperBound] = await this.transformLimits(limits)
         const calldata = (await this.makeEncoder()).encodeBurnAmbientAll
-            (lowerBound, upperBound, this.maskSurplusFlag(opts))
+            (lowerBound, upperBound, this.maskSurplusFlag(opts), this.applyLpConduit(opts))
         return this.sendCmd(calldata)
     }
 
@@ -162,7 +162,7 @@ export class CrocPoolView {
         let [lowerBound, upperBound] = await this.transformLimits(limits)
         let roundLotLiq = roundForConcLiq(liq)
         const calldata = (await this.makeEncoder()).encodeBurnConc
-            (range[0], range[1], roundLotLiq, lowerBound, upperBound, this.maskSurplusFlag(opts))
+            (range[0], range[1], roundLotLiq, lowerBound, upperBound, this.maskSurplusFlag(opts), this.applyLpConduit(opts))
         return this.sendCmd(calldata)
     }
 
@@ -170,7 +170,7 @@ export class CrocPoolView {
         Promise<TransactionResponse> {
         let [lowerBound, upperBound] = await this.transformLimits(limits)
         const calldata = (await this.makeEncoder()).encodeHarvestConc
-            (range[0], range[1], lowerBound, upperBound, this.maskSurplusFlag(opts))
+            (range[0], range[1], lowerBound, upperBound, this.maskSurplusFlag(opts), this.applyLpConduit(opts))
         return this.sendCmd(calldata)
     }
 
@@ -189,7 +189,7 @@ export class CrocPoolView {
         let [lowerBound, upperBound] = await this.transformLimits(limits)
 
         const calldata = (await this.makeEncoder()).encodeMintAmbient(
-            await weiQty, isQtyBase, lowerBound, upperBound, this.maskSurplusFlag(opts))
+            await weiQty, isQtyBase, lowerBound, upperBound, this.maskSurplusFlag(opts), this.applyLpConduit(opts))
         return this.sendCmd(calldata, {value: await msgVal})
     }
 
@@ -250,13 +250,18 @@ export class CrocPoolView {
         let [lowerBound, upperBound] = await this.transformLimits(await saneLimits)
         
         const calldata = (await this.makeEncoder()).encodeMintConc(range[0], range[1],
-            await weiQty, isQtyBase, lowerBound, upperBound, this.maskSurplusFlag(opts))
+            await weiQty, isQtyBase, lowerBound, upperBound, this.maskSurplusFlag(opts), this.applyLpConduit(opts))
         return this.sendCmd(calldata, { value: await msgVal })
     }
 
     private maskSurplusFlag (opts?: CrocLpOpts): number {
         if (!opts || opts.surplus === undefined) { return this.maskSurplusFlag({surplus: false})}
         return encodeSurplusArg(opts.surplus, this.useTrueBase)
+    }
+
+    private applyLpConduit (opts?: CrocLpOpts): string {
+        if (!opts || opts.lpConduit === undefined) { return AddressZero }
+        return opts.lpConduit;
     }
 
     private async msgValAmbient (qty: TokenQty, isQtyBase: boolean, limits: PriceRange, 
@@ -333,5 +338,6 @@ export class CrocPoolView {
 }
 
 export interface CrocLpOpts {
-    surplus?: CrocSurplusFlags
+    surplus?: CrocSurplusFlags,
+    lpConduit?: string
 }


### PR DESCRIPTION
Fixes #24 

Exposes the `lpConduit` parameter to the SDK for mint/burn actions.

Tests were not passing prior to this PR. Demo code included to test functionality.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
