### PR TITLE
Fix UNI token approval

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,7 +1,7 @@
 import { CrocContext } from "./context";
 import { Contract, BigNumber, ethers } from "ethers";
 import { TransactionResponse } from "@ethersproject/providers";
-import { AddressZero } from "@ethersproject/constants";
+import { AddressZero, MaxUint256 } from "@ethersproject/constants";
 import { MAX_LIQ } from "./constants";
 import { toDisplayQty, fromDisplayQty } from "./utils/token";
 
@@ -26,7 +26,7 @@ export class CrocTokenView {
     if (this.isNativeEth) {
       return undefined;
     }
-    const weiQty = BigNumber.from(2).pow(120); // Lots of 0 bytes in calldata to save gas
+    const weiQty = MaxUint256;
 
     // We want to hardcode the gas limit, so we can manually pad it from the estimated
     // transaction. The default value is low gas calldata, but Metamask and other wallets


### PR DESCRIPTION
Fixes #22

UNI token is unsupported by the Ambient frontend because the SDK tries to save ~1% of gas on an already cheap approval transaction that most users would only send a couple of times. 

While a finite approval has slightly cheaper calldata, some tokens (ironically UNI, as well as USDT, DAI, ARB, maybe others) have an optimization for infinite allowances that makes `transferFrom` calls cheaper - they don't update the allowance if it's infinite, so this saves an `SSTORE` and an `Approval` event (for some tokens). These are much greater savings compared to the calldata optimization, and they don't just happen once.

So I believe it's reasonable to go with the industry standard for approvals instead of saving a bit of gas in calldata. Unless maintaining a list of exceptions sounds worthwhile to you.

- [x] Tests pass _(tests are unaffected)_
- [X] Appropriate changes to README are included in PR _(no changes needed)_
