### PR TITLE
Add chain checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crocswap-libs/sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "🛠🐊🛠 An SDK for building applications on top of CrocSwap",
   "author": "Ben Wolski <ben@crocodilelabs.io>",
   "repository": "https://github.com/CrocSwap/sdk.git",

--- a/src/context.ts
+++ b/src/context.ts
@@ -140,7 +140,6 @@ export async function ensureChain(cntx: CrocContext) {
       throw new Error('No network selected in the wallet')
   }
   const contextNetwork = cntx.chain
-  console.log('comparing wallet chain', walletNetwork.chainId, 'and context chain', BigInt(contextNetwork.chainId))
   if (walletNetwork.chainId !== BigInt(contextNetwork.chainId)) {
       throw new Error(`Wrong chain selected in the wallet: expected ${contextNetwork.displayName} (${contextNetwork.chainId}) but got ${walletNetwork.name} (0x${Number(walletNetwork.chainId).toString(16)})`)
   }

--- a/src/encoding/knockout.ts
+++ b/src/encoding/knockout.ts
@@ -1,4 +1,4 @@
-import { BigNumberish, ethers } from "ethers";
+import { ethers } from "ethers";
 
 export class KnockoutEncoder {
     constructor(base: string, quote: string, poolIdx: number) {
@@ -13,21 +13,21 @@ export class KnockoutEncoder {
     private poolIdx: number;
     private abiCoder: ethers.AbiCoder;
 
-    encodeKnockoutMint (qty: BigNumberish, lowerTick:number, upperTick: number,
+    encodeKnockoutMint (qty: bigint, lowerTick:number, upperTick: number,
         isBid: boolean, useSurplusFlags: number): string {
         const MINT_SUBCMD = 91
         const suppArgs = this.abiCoder.encode(["uint128", "bool"], [qty, false])
         return this.encodeCommonArgs(MINT_SUBCMD, lowerTick, upperTick, isBid, useSurplusFlags, suppArgs)
     }
 
-    encodeKnockoutBurnQty (qty: BigNumberish, lowerTick:number, upperTick: number,
+    encodeKnockoutBurnQty (qty: bigint, lowerTick:number, upperTick: number,
         isBid: boolean, useSurplusFlags: number): string {
         const BURN_SUBCMD = 92
         const suppArgs = this.abiCoder.encode(["uint128", "bool", "bool"], [qty, false, false])
         return this.encodeCommonArgs(BURN_SUBCMD, lowerTick, upperTick, isBid, useSurplusFlags, suppArgs)
     }
 
-    encodeKnockoutBurnLiq (liq: BigNumberish, lowerTick:number, upperTick: number,
+    encodeKnockoutBurnLiq (liq: bigint, lowerTick:number, upperTick: number,
         isBid: boolean, useSurplusFlags: number): string {
         const BURN_SUBCMD = 92
         const suppArgs = this.abiCoder.encode(["uint128", "bool", "bool"], [liq, true, true])

--- a/src/knockout.ts
+++ b/src/knockout.ts
@@ -1,5 +1,5 @@
 import { TransactionResponse } from 'ethers';
-import { CrocContext } from './context';
+import { CrocContext, ensureChain } from './context';
 import { CrocEthView, CrocTokenView, sortBaseQuoteViews, TokenQty } from './tokens';
 import { ZeroAddress } from 'ethers';
 import { KnockoutEncoder } from "./encoding/knockout";
@@ -88,8 +88,9 @@ export class CrocKnockoutHandle {
       Promise<TransactionResponse> {
       let cntx = await this.context
       if (txArgs === undefined) { txArgs = {} }
+      await ensureChain(cntx)
       const gasEst = await cntx.dex.userCmd.estimateGas(KNOCKOUT_PATH, calldata, txArgs)
-      Object.assign(txArgs, { gasLimit: gasEst + GAS_PADDING})
+      Object.assign(txArgs, { gasLimit: gasEst + GAS_PADDING, chainId: cntx.chain.chainId })
       return cntx.dex.userCmd(KNOCKOUT_PATH, calldata, txArgs);
   }
 

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -1,4 +1,4 @@
-import { CrocContext } from "./context";
+import { CrocContext, ensureChain } from "./context";
 import { decodeCrocPrice, toDisplayPrice, bigIntToFloat, toDisplayQty, fromDisplayPrice, roundForConcLiq, concDepositSkew, pinTickLower, pinTickUpper, neighborTicks, pinTickOutside, tickToPrice, concBaseSlippagePrice, concQuoteSlippagePrice } from './utils';
 import { CrocEthView, CrocTokenView, sortBaseQuoteViews, TokenQty } from './tokens';
 import { TransactionResponse } from 'ethers';
@@ -129,8 +129,9 @@ export class CrocPoolView {
         let calldata = encoder.encodeInitialize(await spotPrice)
 
         let cntx = await this.context
+        await ensureChain(cntx)
         const gasEst = await cntx.dex.userCmd.estimateGas(cntx.chain.proxyPaths.cold, calldata, txArgs)
-        Object.assign(txArgs, { gasLimit: gasEst + GAS_PADDING})
+        Object.assign(txArgs, { gasLimit: gasEst + GAS_PADDING, chainId: cntx.chain.chainId })
         return cntx.dex.userCmd(cntx.chain.proxyPaths.cold, calldata, txArgs)
     }
 
@@ -190,8 +191,9 @@ export class CrocPoolView {
         Promise<TransactionResponse> {
         let cntx = await this.context
         if (txArgs === undefined) { txArgs = {} }
+        await ensureChain(cntx)
         const gasEst = await cntx.dex.userCmd.estimateGas(cntx.chain.proxyPaths.liq, calldata, txArgs)
-        Object.assign(txArgs, { gasLimit: gasEst + GAS_PADDING})
+        Object.assign(txArgs, { gasLimit: gasEst + GAS_PADDING, chainId: cntx.chain.chainId })
         return cntx.dex.userCmd(cntx.chain.proxyPaths.liq, calldata, txArgs);
     }
 

--- a/src/position.ts
+++ b/src/position.ts
@@ -6,7 +6,7 @@ export type BlockTag = number | string
 
 export class CrocPositionView {
     constructor (base: CrocTokenView, quote: CrocTokenView, owner: Address, context: Promise<CrocContext>) {
-        [this.baseToken, this.quoteToken] = 
+        [this.baseToken, this.quoteToken] =
             sortBaseQuoteViews(base, quote)
         this.owner = owner
         this.context = context
@@ -15,24 +15,24 @@ export class CrocPositionView {
     async queryRangePos (lowerTick: number, upperTick: number, block?: BlockTag) {
         let blockArg = toCallArg(block)
         let context = await this.context
-        return context.query.queryRangePosition(this.owner, 
-            this.baseToken.tokenAddr, this.quoteToken.tokenAddr, 
+        return context.query.queryRangePosition(this.owner,
+            this.baseToken.tokenAddr, this.quoteToken.tokenAddr,
             context.chain.poolIndex, lowerTick, upperTick, blockArg)
     }
 
     async queryAmbient (block?: BlockTag) {
        let blockArg = toCallArg(block)
         let context = await this.context
-        return context.query.queryAmbientPosition(this.owner, 
-            this.baseToken.tokenAddr, this.quoteToken.tokenAddr, 
+        return context.query.queryAmbientPosition(this.owner,
+            this.baseToken.tokenAddr, this.quoteToken.tokenAddr,
             context.chain.poolIndex, blockArg)
     }
 
     async queryAmbientPos (block?: BlockTag) {
         let blockArg = toCallArg(block)
         let context = await this.context
-        return context.query.queryAmbientTokens(this.owner, 
-            this.baseToken.tokenAddr, this.quoteToken.tokenAddr, 
+        return context.query.queryAmbientTokens(this.owner,
+            this.baseToken.tokenAddr, this.quoteToken.tokenAddr,
             context.chain.poolIndex, blockArg)
     }
 
@@ -40,21 +40,21 @@ export class CrocPositionView {
         let blockArg = toCallArg(block)
         let context = await this.context
         let pivotTick = isBid ? lowerTick : upperTick
-        
+
         const pivotTime = (await context.query.queryKnockoutPivot(
-            this.baseToken.tokenAddr, this.quoteToken.tokenAddr, 
+            this.baseToken.tokenAddr, this.quoteToken.tokenAddr,
             context.chain.poolIndex, isBid, pivotTick, blockArg)).pivot
 
         return context.query.queryKnockoutTokens(this.owner,
-                this.baseToken.tokenAddr, this.quoteToken.tokenAddr, 
+                this.baseToken.tokenAddr, this.quoteToken.tokenAddr,
                 context.chain.poolIndex, pivotTime, isBid, lowerTick, upperTick, blockArg)
-    }   
+    }
 
     async queryRewards (lowerTick: number, upperTick: number, block?: BlockTag) {
         let blockArg = toCallArg(block)
         let context = await this.context
-        return (await context.query.queryConcRewards(this.owner, 
-            this.baseToken.tokenAddr, this.quoteToken.tokenAddr, 
+        return (await context.query.queryConcRewards(this.owner,
+            this.baseToken.tokenAddr, this.quoteToken.tokenAddr,
             context.chain.poolIndex, lowerTick, upperTick, blockArg))
     }
 

--- a/src/recipes/reposition.ts
+++ b/src/recipes/reposition.ts
@@ -6,6 +6,7 @@ import { CrocTokenView } from "../tokens";
 import { encodeCrocPrice, tickToPrice } from "../utils";
 import { baseTokenForConcLiq, concDepositBalance, quoteTokenForConcLiq } from "../utils/liquidity";
 import { GAS_PADDING } from "../utils";
+import { ensureChain } from "../context";
 
 
 interface RepositionTarget {
@@ -36,8 +37,9 @@ export class CrocReposition {
         const directive = await this.formatDirective()
         const cntx = await this.pool.context
         const path = cntx.chain.proxyPaths.long
+        await ensureChain(cntx)
         const gasEst = await cntx.dex.userCmd.estimateGas(path, directive.encodeBytes())
-        return cntx.dex.userCmd(path, directive.encodeBytes(), { gasLimit: gasEst + GAS_PADDING})
+        return cntx.dex.userCmd(path, directive.encodeBytes(), { gasLimit: gasEst + GAS_PADDING, chainId: cntx.chain.chainId })
     }
 
     async simStatic() {

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -1,5 +1,5 @@
 import { TransactionResponse, ZeroAddress, ethers } from "ethers";
-import { CrocContext } from './context';
+import { CrocContext, ensureChain } from './context';
 import { CrocPoolView } from './pool';
 import { decodeCrocPrice, getUnsignedRawTransaction } from './utils';
 import { CrocEthView, CrocTokenView, sortBaseQuoteViews, TokenQty } from './tokens';
@@ -55,8 +55,9 @@ export class CrocSwapPlan {
   }
 
   async swap (args: CrocSwapExecOpts = { }): Promise<TransactionResponse> {
+    await ensureChain(await this.context);
     const gasEst = await this.estimateGas(args)
-    const callArgs = Object.assign({gasEst: gasEst }, args)
+    const callArgs = Object.assign({ gasEst: gasEst, chainId: (await this.context).chain.chainId }, args)
     return this.sendTx(Object.assign({}, args, callArgs))
   }
 
@@ -197,7 +198,7 @@ export class CrocSwapPlan {
     const txArgs = await this.attachEthMsg(surplusArg)
 
     if (gasEst) {
-      Object.assign(txArgs, { gasLimit: gasEst + GAS_PADDING})
+      Object.assign(txArgs, { gasLimit: gasEst + GAS_PADDING });
     }
 
     return txArgs


### PR DESCRIPTION
Frontend as it is has checks to prevent running with a mismatched provider and signer chains, but additional measures are necessary to work around wallet bugs (just a month ago there was a Metamask bug which caused transactions to be sent to the wrong chain). This PR adds checks that enforce chain parity before any transaction is sent.

> It's a good idea to open an issue first for discussion.

- [X] Tests pass
- [X] Appropriate changes to README are included in PR
