### PR TITLE
Attach ETH to vault deposit transaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crocswap-libs/sdk",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "🛠🐊🛠 An SDK for building applications on top of CrocSwap",
   "author": "Ben Wolski <ben@crocodilelabs.io>",
   "repository": "https://github.com/CrocSwap/sdk.git",

--- a/src/vaults/tempest.ts
+++ b/src/vaults/tempest.ts
@@ -19,7 +19,11 @@ export class TempestVault {
     async depositZap (qty: TokenQty): Promise<TransactionResponse> {
         let owner = ((await this.context).actor as Signer).getAddress()
         let weiQty = this.token1.normQty(qty);
-        return (await this.vault).deposit(await weiQty, owner, true)
+        let txArgs = {};
+        if (this.token1.isNativeEth) {
+            txArgs = { value: await weiQty };
+        }
+        return (await this.vault).deposit(await weiQty, owner, true, txArgs)
     }
 
     /* @notice Sends a transaction to redeem shares in vault position back into token1


### PR DESCRIPTION
Fix ETH/WBTC vault deposits failing due to ETH not being attached to the transaction.

- [X] Tests pass
- [X] Appropriate changes to README are included in PR
