### PR TITLE
Add token address normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crocswap-libs/sdk",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "🛠🐊🛠 An SDK for building applications on top of CrocSwap",
   "author": "Ben Wolski <ben@crocodilelabs.io>",
   "repository": "https://github.com/CrocSwap/sdk.git",

--- a/src/croc.ts
+++ b/src/croc.ts
@@ -188,6 +188,7 @@ class TokenRepo {
     /* Either generates or loads a previously cached token view object.
      * @param tokenAddr The Ethereum address of the token contract. */
     materialize (tokenAddr: string): CrocTokenView {
+        tokenAddr = tokenAddr.toLowerCase()
         let tokenView = this.tokenViews.get(tokenAddr)
         if (!tokenView) {
             tokenView = new CrocTokenView(this.context, tokenAddr)


### PR DESCRIPTION
Fix duplicate RPC calls being sent for token data because their addresses weren't being normalized.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
