### PR TITLE
enable token approval resets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crocswap-libs/sdk",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "🛠🐊🛠 An SDK for building applications on top of CrocSwap",
   "author": "Ben Wolski <ben@crocodilelabs.io>",
   "repository": "https://github.com/CrocSwap/sdk.git",

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -47,7 +47,7 @@ export class CrocTokenView {
       return undefined;
     }
 
-    const weiQty = approveQty ? await this.normQty(approveQty) : MaxUint256
+    const weiQty = approveQty !== undefined ? await this.normQty(approveQty) : MaxUint256
 
     await ensureChain(await this.context)
     // We want to hardcode the gas limit, so we can manually pad it from the estimated


### PR DESCRIPTION
allow quantity of zero to be passed to the approval function in order to reset a token approval

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
