### PR TITLE
Fix silently returning an incorrect swap impact result

### DIFF
--- a/src/swap.ts
+++ b/src/swap.ts
@@ -161,6 +161,9 @@ export class CrocSwapPlan {
       (this.baseToken.tokenAddr, this.quoteToken.tokenAddr, (await this.context).chain.poolIndex,
       this.sellBase, this.qtyInBase, await this.qty, TIP, limitPrice);
 
+    if ((impact[0] > 0 && impact[1] > 0) || (impact[0] < 0 && impact[1] < 0))
+      throw new Error("Invalid impact: base and quote flows have matching signs")
+
     const baseQty = this.baseToken.toDisplay(impact[0] < 0 ? -impact[0] : impact[0])
     const quoteQty = this.quoteToken.toDisplay(impact[1] < 0 ? -impact[1] : impact[1])
     const spotPrice = decodeCrocPrice(impact[2])


### PR DESCRIPTION
Sometimes in low liquidity situations the `calcImpact` method returns positive values for both the base and quote flows, which are obviously incorrect. Currently the SDK interprets that as a very high input of very high output, this PR changes this behavior to throw an error instead. It's not the best way to signal this error (because it could be confused by the caller with a recoverable RPC exception), but anything better would require an API change.

- [X] Tests pass
- [X] Appropriate changes to README are included in PR
