### PR TITLE
fix bound limit math

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crocswap-libs/sdk",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "🛠🐊🛠 An SDK for building applications on top of CrocSwap",
   "author": "Ben Wolski <ben@crocodilelabs.io>",
   "repository": "https://github.com/CrocSwap/sdk.git",

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -227,8 +227,8 @@ export class CrocPoolView {
             }
         }
 
-        return this.untransformLimits(
-                [Math.max(amplifyLower, boundLower), Math.min(amplifyUpper, boundUpper)])
+        return this.untransformLimits(  
+                [Math.min(amplifyLower, boundLower), Math.max(amplifyUpper, boundUpper)])
     }
 
     private rangeToPrice (range: TickRange): PriceRange {


### PR DESCRIPTION
Fixes edge case failure to mint liquidity position when max range boundary is almost exactly the pool price.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
