### PR TITLE
Vendor Ethers' sendTransaction method to bypass wallet's RPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crocswap-libs/sdk",
-  "version": "2.0.14",
+  "version": "2.1.0",
   "description": "🛠🐊🛠 An SDK for building applications on top of CrocSwap",
   "author": "Ben Wolski <ben@crocodilelabs.io>",
   "repository": "https://github.com/CrocSwap/sdk.git",

--- a/src/vaults/tempest.ts
+++ b/src/vaults/tempest.ts
@@ -2,6 +2,7 @@ import { Contract, Signer, TransactionResponse, Typed } from "ethers";
 import { TEMPEST_VAULT_ABI } from "../abis/external/TempestVaultAbi";
 import { CrocContext, ensureChain } from "../context";
 import { CrocTokenView, TokenQty } from "../tokens";
+import { sendTransaction } from "../vendorEthers";
 
 export type TempestStrategy = 'rswEth' | 'symetricAmbient'
 
@@ -29,9 +30,11 @@ export class TempestVault {
         await ensureChain(await this.context)
         switch (this.strategy) {
             case 'symetricAmbient':
-                return (await this.vaultWrite).deposit(await weiQty, owner, Typed.bool(true), txArgs)
+                const populatedTx = await (await this.vaultWrite).deposit.populateTransaction(await weiQty, owner, Typed.bool(true), txArgs);
+                return sendTransaction(await this.context, populatedTx);
             case 'rswEth':
-                return (await this.vaultWrite).deposit(await weiQty, owner, Typed.bytes('0x'), txArgs)
+                const populatedTxRsw = await (await this.vaultWrite).deposit.populateTransaction(await weiQty, owner, Typed.bytes('0x'), txArgs);
+                return sendTransaction(await this.context, populatedTxRsw);
         }
     }
 
@@ -45,9 +48,11 @@ export class TempestVault {
         await ensureChain(await this.context)
         switch (this.strategy) {
             case 'symetricAmbient':
-                return (await this.vaultWrite).redeem(await weiQty, owner, owner, Typed.uint256(await minWeiQty), Typed.bool(true))
+                const populatedTx = await (await this.vaultWrite).redeem.populateTransaction(await weiQty, owner, owner, Typed.uint256(await minWeiQty), Typed.bool(true));
+                return sendTransaction(await this.context, populatedTx);
             case 'rswEth':
-                return (await this.vaultWrite).redeem(await weiQty, owner, owner, Typed.bytes('0x'))
+                const populatedTxRsw = await (await this.vaultWrite).redeem.populateTransaction(await weiQty, owner, owner, Typed.bytes('0x'));
+                return sendTransaction(await this.context, populatedTxRsw);
         }
     }
 

--- a/src/vendorEthers.ts
+++ b/src/vendorEthers.ts
@@ -1,0 +1,102 @@
+import { ethers, isCallException, isError } from "ethers";
+import { CrocContext } from "./context";
+
+export async function sendTransaction(cntx: CrocContext, populatedTx: ethers.ContractTransaction): Promise<ethers.TransactionResponse> {
+  // Every Ethers provider is actually a JsonRpcApiProvider, so we can use
+  // its methods when needed.
+  const params = (cntx.provider as ethers.JsonRpcApiProvider).getRpcTransaction(populatedTx);
+  return await ethers_sendTransaction(cntx, params);
+}
+
+// Almost exact copy of `ethers.providers.JsonRpcSigner.sendTransaction` which
+// doesn't use the wallet provider for RPC calls, only to send the transaction.
+//
+// https://github.com/ethers-io/ethers.js/blob/v6.13.5/src.ts/providers/provider-jsonrpc.ts#L353-L415
+export async function ethers_sendTransaction(cntx: CrocContext, txParams: ethers.JsonRpcTransactionRequest): Promise<ethers.TransactionResponse> {
+  console.log('manual ethers_sendTransaction', txParams);
+  const signer = cntx.actor;
+  const walletProvider = signer.provider as ethers.JsonRpcApiProvider;
+  if (!signer || !walletProvider)
+    throw new Error("Wallet isn't connected");
+
+  if (!txParams.from)
+    txParams.from = (await signer.getAddress()).toLowerCase();
+
+  // This cannot be mined any earlier than any recent block
+  const blockNumber = await cntx.provider.getBlockNumber();
+
+  // Send the transaction
+  const hash = await walletProvider.send('eth_sendTransaction', [txParams]);
+
+  // Unfortunately, JSON-RPC only provides and opaque transaction hash
+  // for a response, and we need the actual transaction, so we poll
+  // for it; it should show up very quickly
+  return await (new Promise((resolve, reject) => {
+    const timeouts = [1000, 100];
+    let invalids = 0;
+
+    const checkTx = async () => {
+
+      try {
+        // Try getting the transaction
+        const tx = await cntx.provider.getTransaction(hash);
+
+        if (tx != null) {
+          resolve(tx.replaceableTransaction(blockNumber));
+          return;
+        }
+
+      } catch (error) {
+
+        // If we were cancelled: stop polling.
+        // If the data is bad: the node returns bad transactions
+        // If the network changed: calling again will also fail
+        // If unsupported: likely destroyed
+        if (isError(error, "CANCELLED") || isError(error, "BAD_DATA") ||
+          isError(error, "NETWORK_ERROR") || isError(error, "UNSUPPORTED_OPERATION")) {
+
+          if (error.info == null) { error.info = {}; }
+          error.info.sendTransactionHash = hash;
+
+          reject(error);
+          return;
+        }
+
+        // Stop-gap for misbehaving backends; see #4513
+        if (isError(error, "INVALID_ARGUMENT")) {
+          invalids++;
+          if (error.info == null) { error.info = {}; }
+          error.info.sendTransactionHash = hash;
+          if (invalids > 10) {
+            reject(error);
+            return;
+          }
+        }
+      }
+
+      // Wait another 4 seconds
+      setTimeout(() => { checkTx(); }, timeouts.pop() || 4000);
+    };
+    checkTx();
+  }));
+}
+
+// Almost exact copy of `ethers.contract.BaseContractMethod.staticCallResult`.
+//
+// https://github.com/ethers-io/ethers.js/blob/v6.13.5/src.ts/contract/contract.ts#L328-L347
+export async function staticCall(cntx: CrocContext, populatedTx: ethers.ContractTransaction, contract: ethers.Contract, fragment: ethers.FunctionFragment): Promise<ethers.Result> {
+  const runner = cntx.provider;
+
+  let result = "0x";
+  try {
+    result = await runner.call(populatedTx);
+  } catch (error: any) {
+    if (isCallException(error) && error.data) {
+      throw contract.interface.makeError(error.data, populatedTx);
+    }
+    throw error;
+  }
+
+  const decoded = contract.interface.decodeFunctionResult(fragment, result);
+  return decoded.length == 1 ? decoded[0] : decoded;
+};

--- a/src/vendorEthers.ts
+++ b/src/vendorEthers.ts
@@ -13,7 +13,6 @@ export async function sendTransaction(cntx: CrocContext, populatedTx: ethers.Con
 //
 // https://github.com/ethers-io/ethers.js/blob/v6.13.5/src.ts/providers/provider-jsonrpc.ts#L353-L415
 export async function ethers_sendTransaction(cntx: CrocContext, txParams: ethers.JsonRpcTransactionRequest): Promise<ethers.TransactionResponse> {
-  console.log('manual ethers_sendTransaction', txParams);
   const signer = cntx.actor;
   const walletProvider = signer.provider as ethers.JsonRpcApiProvider;
   if (!signer || !walletProvider)


### PR DESCRIPTION
This PR does two things:

1. Adds a fallback to the frontend's provider if sending an `eth_estimateGas` call through the wallet's RPC fails or times out.
2. Vendors some Ethers methods with minimal changes to reroute their RPC calls to the frontend's provider so that the only call sent to the wallet is to submit the transaction.

This fixes the longstanding issue of the frontend partially breaking due to the user having a malfunctioning RPC in their wallet. These changes should have no side effects for most users because the vast majority of RPC calls already go through the frontend's RPC, and the vendored code is almost verbatim what we already run.